### PR TITLE
63515 added output of a JSON-formatted metrics representing the entire run

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,8 @@
   {getopt, ".*",
    {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},
   {ibrowse, ".*", {git, "https://github.com/cloudant/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},
-  {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}}
+  {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}},
+  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.14.7"}}}
  ]}.
 
 {erl_opts, [{src_dirs, [src]},
@@ -19,7 +20,8 @@
     getopt,
     goldrush,
     lager,
-    ibrowse
+    ibrowse,
+    jiffy
 ]}.
 
 %% The value of +Q here is for 1.2 million ports, but the process

--- a/src/basho_bench_stats.erl
+++ b/src/basho_bench_stats.erl
@@ -67,6 +67,8 @@ op_complete(Op, {ok, Units}, ElapsedUs) ->
             gen_server:cast({global, ?MODULE}, {Op, {ok, Units}, ElapsedUs});
         false ->
             folsom_metrics:notify_existing_metric({latencies, Op}, ElapsedUs, histogram),
+            folsom_metrics:notify_existing_metric({overall_latencies, Op}, ElapsedUs, histogram),
+            folsom_metrics:notify_existing_metric({overall_units, Op}, {inc, Units}, counter),
             folsom_metrics:notify_existing_metric({units, Op}, {inc, Units}, counter)
     end,
     ok;
@@ -111,6 +113,8 @@ init([]) ->
     %% successful operations
     [begin
          folsom_metrics:new_histogram({latencies, Op}, slide, basho_bench_config:get(report_interval)),
+         folsom_metrics:new_histogram({overall_latencies, Op}, uniform, 16384),
+         folsom_metrics:new_counter({overall_units, Op}),
          folsom_metrics:new_counter({units, Op})
      end || Op <- Ops ++ Measurements],
 
@@ -156,6 +160,8 @@ handle_cast({Op, {ok, Units}, ElapsedUs}, State = #state{last_write_time = LWT, 
             NewState = State
     end,
     folsom_metrics:notify_existing_metric({latencies, Op}, ElapsedUs, histogram),
+    folsom_metrics:notify_existing_metric({overall_latencies, Op}, ElapsedUs, histogram),
+    folsom_metrics:notify_existing_metric({overall_units, Op}, {inc, Units}, counter),
     folsom_metrics:notify_existing_metric({units, Op}, {inc, Units}, counter),
     {noreply, NewState};
 handle_cast(_, State) ->
@@ -171,6 +177,9 @@ terminate(_Reason, #state{stats_writer=Module}=State) ->
     %% Do the final stats report and write the errors file
     process_stats(os:timestamp(), State),
     report_total_errors(State),
+
+    %% Report run wide statistics
+    process_global_stats(State),
 
     Module:terminate(State#state.stats_writer_data).
 
@@ -269,6 +278,16 @@ process_stats(Now, #state{stats_writer=Module}=State) ->
         false ->
             ok
     end.
+
+process_global_stats(#state{stats_writer=Module}=State) ->
+    %% Iterate over all Ops and report out each set of Statistics
+    lists:foreach(fun(Op) ->
+        %% Report out the statistics captured across the whole run
+        Stats = folsom_metrics:get_histogram_statistics({overall_latencies, Op}),
+        Errors = error_counter(Op),
+        Units = folsom_metrics:get_metric_value({overall_units, Op}),
+        Module:report_global_stats(Op, Stats, Errors, Units)
+    end, State#state.ops).
 
 %%
 %% Write latency info for a given op to the appropriate CSV. Returns the

--- a/src/basho_bench_stats_writer_csv.erl
+++ b/src/basho_bench_stats_writer_csv.erl
@@ -35,6 +35,7 @@
          terminate/1,
          process_summary/5,
          report_error/3,
+         report_global_stats/4,
          report_latency/7]).
 
 -include("basho_bench.hrl").
@@ -46,6 +47,9 @@ new(Ops, Measurements) ->
 
     %% Setup output file handles for dumping periodic CSV of histogram results.
     [erlang:put({csv_file, X}, measurement_csv_file(X)) || X <- Measurements],
+
+    %% Initialize an empty set of json statistics
+    erlang:put(run_metrics, [ {X,""} || {X,_} <- Ops]),
 
     TestDir = basho_bench:get_test_dir(),
     %% Setup output file w/ counters for total requests, errors, etc.
@@ -67,6 +71,11 @@ new(Ops, Measurements) ->
 
 terminate({SummaryFile, ErrorsFile}) ->
     ?INFO("module=~s event=stop stats_sink=csv\n", [?MODULE]),
+
+    %% write out run-wide statistics before exiting
+    RunStatsType = basho_bench_config:get(run_statistics_output_format, csv),
+    dump_run_statistics(RunStatsType),
+
     [ok = file:close(F) || {{csv_file, _}, F} <- erlang:get()],
     ok = file:close(SummaryFile),
     ok = file:close(ErrorsFile),
@@ -87,6 +96,46 @@ report_error({_SummaryFile, ErrorsFile},
     file:write(ErrorsFile,
                io_lib:format("\"~w\",\"~w\"\n",
                              [Key, Count])).
+
+report_global_stats({Op,_}, Stats, Errors, Units) ->
+    %% Build up JSON structure representing statistices collected in folsom
+    P = proplists:get_value(percentile, Stats),
+    JsonElements0 = lists:foldl(fun(K, Acc) ->
+        case K of
+            %% Unpack percentiles list
+            percentile ->
+                [
+                    % we skip p50 since we have the median
+                    {p75, proplists:get_value(75, P)},
+                    {p90, proplists:get_value(90, P)},
+                    {p95, proplists:get_value(95, P)},
+                    {p99, proplists:get_value(99, P)},
+                    {p999, proplists:get_value(999, P)}
+                ] ++ Acc;
+
+            %% We ignore the histogram as it will not be used in the analysis
+            histogram -> Acc;
+
+            %% Rename arithmetic_mean to mean {<key>, <value>}
+            arithmetic_mean ->
+                [{mean, proplists:get_value(K, Stats)} | Acc];
+
+            %% All other metrics get turned into {<key>, <value>}
+            _ ->
+                [{K, proplists:get_value(K, Stats)} | Acc]
+        end
+    end, [], proplists:get_keys(Stats)),
+
+    %% insert correct units count
+    JsonElements1 = lists:keyreplace(n, 1, JsonElements0, {'n', Units}),
+
+    %% insert error counts
+    JsonElements2 = [{basho_errors, Errors} | JsonElements1],
+
+    JsonMetrics0 = erlang:get(run_metrics),
+    JsonMetrics = lists:keyreplace(Op, 1, JsonMetrics0, {Op, {JsonElements2}}),
+    %?DEBUG("Generated Json:\n~w",[JsonElements]),
+    erlang:put(run_metrics, JsonMetrics).
 
 report_latency({_SummaryFile, _ErrorsFile},
                Elapsed, Window, Op,
@@ -132,6 +181,54 @@ measurement_csv_file({Label, _Op}) ->
     {ok, F} = file:open(Fname, [raw, binary, write]),
     ok = file:write(F, <<"elapsed, window, n, min, mean, median, 95th, 99th, 99_9th, max, errors\n">>),
     F.
+
+
+
+dump_run_statistics(RunStatsType) ->
+    Lines = stringify_stats(RunStatsType, erlang:get(run_metrics)),
+    TestDir = basho_bench:get_test_dir(),
+    FileName = filename:join([TestDir, "run_statistics." ++ atom_to_list(RunStatsType)]),
+    write_run_statistics(FileName, Lines).
+
+stringify_stats(_RunStatsType=json, RunMetrics) ->
+    [ jiffy:encode( {[{recordedMetrics, {RunMetrics}}]}, [pretty] ) ];
+stringify_stats(_RunStatsType=csv, RunMetrics) ->
+    % Ordered output of fields
+    OrderedFields = [n, mean, geometric_mean, harmonic_mean,
+        variance, standard_deviation, skewness, kurtosis,
+        median, p75, p90, p95, p99, p999,
+        min, max, basho_errors],
+
+    %% Remove all duplicates and sort list of available headers
+    StrHeader = string:join(
+        lists:map(fun atom_to_list/1, [op|OrderedFields]), ", "),
+    StringyfiedHeader =  io_lib:format("~s\n", [StrHeader]),
+
+    %% Loop over each metric and build each line of the CSV file and write it out
+    Lines = lists:foldl(fun(Op, Lines) ->
+        {MetricsObj} = proplists:get_value(Op, RunMetrics),
+        CsvLine = lists:foldl(fun(K, Acc) ->
+            StrVal = io_lib:format("~w", [proplists:get_value(K, MetricsObj, "")]),
+            [StrVal|Acc]
+        end, [], OrderedFields),
+
+        OpStr = string:join( [atom_to_list(Op) | lists:reverse(CsvLine)], ", "),
+        [io_lib:format("~s\n", [OpStr]) | Lines]
+
+    end, [], proplists:get_keys(RunMetrics)),
+    [StringyfiedHeader|Lines].
+
+write_run_statistics(FileName, Lines)->
+    {ok, GlobalMetricsFile} = file:open(
+        FileName,
+        [raw, binary, write]
+    ),
+    
+    %% Write lines to file
+    lists:foreach(fun(Line) ->
+        ok = file:write(GlobalMetricsFile, Line)
+    end, Lines),
+    ok = file:close(GlobalMetricsFile).
 
 normalize_label(Label) when is_list(Label) ->
     replace_special_chars(Label);


### PR DESCRIPTION
Bugzid:  63515

Changes:
- added another histogram for collecting stats across the entire run
- added JSON-formatted output of collected statistics

Generated Output:

``` json
{ "recordedMetrics" : {
"put": {"n":319546,
"standard_deviation":0.9843117238528302,
"median":2,
"harmonic_mean":2.2260478373026475,
"geometric_mean":2.2784470685780045,
"arithmetic_mean":2.3607399247682648,
"min":2,
"max":93,
"p50":2,
"p75":3,
"p90":3,
"p95":3,
"p99":5,
"p999":15,
"variance":0.9688695697141303,
"kurtosis":1163.4918872449086,
"skewness":21.457948218223454
},
"put10": {"n":282077,
"standard_deviation":3.6205383023363447,
"median":17,
"harmonic_mean":17.28713647538748,
"geometric_mean":17.4556781472093,
"arithmetic_mean":17.693165341378418,
"min":15,
"max":242,
"p50":17,
"p75":18,
"p90":20,
"p95":24,
"p99":32,
"p999":50,
"variance":13.10829759868454,
"kurtosis":134.8276758531883,
"skewness":6.980396917158458
}
}
}
```

Questions:
- Is _slide_ the right histogram for this? looks like _slide_ only represents the last window-size worth of stats, might be better to do a _uniform_ histogram.
- I'd be interested in pointers on style and best practices.

cc: @chewbranca @djschlegel2 
