### PR TITLE
64339-fix-basho-bench-stop-issue

### DIFF
--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -124,6 +124,7 @@ main(Args) ->
 
 await_completion(Timeout) ->
     MRef = erlang:monitor(process, whereis(basho_bench_duration)),
+
     receive
         {'DOWN', MRef, process, _Object, _Info} ->
             done

--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -129,6 +129,7 @@ init([SupChild, Id]) ->
     %%
     %% Link the worker and the sub-process to ensure that if either exits, the
     %% other goes with it.
+    %% WorkerPid is the driver process id which is linked with basho_bench_worker id
     WorkerPid = spawn_link(fun() -> worker_init(State) end),
     WorkerPid ! {init_driver, self()},
     receive
@@ -162,6 +163,9 @@ handle_info({'EXIT', Pid, Reason}, State) ->
     #state{worker_pid=WorkerPid} = State,
     case {Reason, Pid} of
         {normal, _} ->
+            %% Worker process exited normally
+            %% Stop this worker and check is there any other alive worker
+            basho_bench_duration:worker_stopping(self()),
             {stop, normal, State};
         {_, WorkerPid} ->
             ?ERROR("Worker ~p exited with ~p~n", [Pid, Reason]),

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -26,7 +26,8 @@
 %% API
 -export([start_link/0,
          workers/0,
-         stop_child/1]).
+         stop_child/1,
+         active_workers/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -45,6 +46,9 @@ workers() ->
 
 stop_child(Id) ->
     supervisor:terminate_child(?MODULE, Id).
+
+active_workers() ->
+    [X || X <- workers(), X =/= undefined].
 
 
 %% ===================================================================


### PR DESCRIPTION
Changed:
- Add a stop_worker method to check whether still have alive worker
- Spwan a procss to kick off stop_worker function when a worker stop

BugzId: 64339

@chewbranca @djschlegel2 
