### PR TITLE
64683 rename basho bench duration module

### DIFF
--- a/Internal.org
+++ b/Internal.org
@@ -5,14 +5,14 @@
 ** basho_bench: main entry point
 *** setup_benchmark: common initialization - logging, basic conditions, environment
 *** run_benchmark: more init, load config, have basho_bench_sup start basho_bench_run_sup+children, send all run() msgs
-*** await_completion: monitors basho_bench_duration to finish, changes is_running mode
+*** await_completion: monitors basho_bench_terminator to finish, changes is_running mode
 *** main: wrapper for handling command line args, setup/run_benchmark
 *** load_source_files: compiles and loads driver contents of source_dir
 *** setup_distributed_work, deploy_module, distribute_app: distribute run across remote nodes
 ** ------- Intermediate Supervisors/Servers -----
 ** basho_bench_sup (supervisor): supervises basho_bench_run_sup and basho_bench_config
-** basho_bench_run_sup (supervisor): supervises basho_bench_duration/_stats/_measurement/_worker_sup
-** basho_bench_duration (gen_server): manages overall run time
+** basho_bench_run_sup (supervisor): supervises basho_bench_terminator/_stats/_measurement/_worker_sup
+** basho_bench_terminator (gen_server): manages overall run time
 *** init: calls prehook when there is one
 *** handle(run): initializes timing information then calls maybe_end to loop until it's time to terminate
 *** terminate: stop basho_bench_worker_sup, call posthook, stop basho_bench_run_sup, mark app as stopped

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -97,7 +97,7 @@ run_benchmark(Configs) ->
     ok = basho_bench_stats:run(),
     ok = basho_bench_measurement:run(),
     ok = basho_bench_worker:run(basho_bench_worker_sup:workers()),
-    ok = basho_bench_duration:run(),
+    ok = basho_bench_terminator:run(),
     application:set_env(basho_bench_app, is_running, true).
 
 
@@ -123,7 +123,8 @@ main(Args) ->
 
 
 await_completion(Timeout) ->
-    MRef = erlang:monitor(process, whereis(basho_bench_duration)),
+    MRef = erlang:monitor(process, whereis(basho_bench_terminator)),
+
     receive
         {'DOWN', MRef, process, _Object, _Info} ->
             done

--- a/src/basho_bench_run_sup.erl
+++ b/src/basho_bench_run_sup.erl
@@ -20,7 +20,7 @@ init([]) ->
         _Driver -> [?CHILD(basho_bench_measurement, worker, Timeout)]
     end,
     Spec = [
-        ?CHILD(basho_bench_duration, worker, Timeout),
+        ?CHILD(basho_bench_terminator, worker, Timeout),
         ?CHILD(basho_bench_stats, worker, Timeout),
         ?CHILD(basho_bench_worker_sup, supervisor, Timeout)
     ] ++ MeasurementDriver,

--- a/src/basho_bench_terminator.erl
+++ b/src/basho_bench_terminator.erl
@@ -1,4 +1,10 @@
--module(basho_bench_duration).
+%% -------------------------------------------------------------------
+%% Check whether to exit besho_bench, exit conditions
+%%     1. run out of duration time
+%%     2. run out of operations even if the duration time had not up
+%% -------------------------------------------------------------------
+
+-module(basho_bench_terminator).
 
 -behavior(gen_server).
 
@@ -15,7 +21,8 @@
     handle_cast/2,
     handle_info/2,
     terminate/2,
-    code_change/3
+    code_change/3,
+    worker_stopping/1
 ]).
 
 -record(state, {
@@ -47,7 +54,7 @@ init([]) ->
 
 handle_call(run, _From, State) ->
     DurationMins = basho_bench_config:get(duration, 1),
-    lager:info("Starting with duration: ~p", [DurationMins]),
+    ?INFO("Starting with duration: ~p", [DurationMins]),
     NewState = State#state{
         start=os:timestamp(),
         duration=DurationMins
@@ -59,6 +66,15 @@ handle_call(remaining, _From, State) ->
     Remaining = (Duration*60) - timer:now_diff(os:timestamp(), Start),
     maybe_end({reply, Remaining, State}).
 
+
+handle_cast({worker_stopping, WorkerPid}, State) ->
+    case basho_bench_worker_sup:active_workers() -- [WorkerPid] of
+        [] ->
+            ?INFO("The application has stopped early!", []),
+            {stop, {shutdown, normal}, State};
+        _ ->
+            maybe_end({noreply, State})
+    end;
 
 handle_cast(_Msg, State) ->
     maybe_end({noreply, State}).
@@ -107,7 +123,6 @@ maybe_end(Return) ->
             {Reply0, ok, State0}
     end,
     #state{start=Start} = State,
-
     case State#state.duration of
         infinity ->
             Return;
@@ -131,3 +146,8 @@ run_hook({Module, Function}) ->
 
 run_hook(no_op) ->
     no_op.
+
+worker_stopping(WorkerPid) ->
+    gen_server:cast(?MODULE, {worker_stopping, WorkerPid}),
+    ok.
+

--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -162,6 +162,9 @@ handle_info({'EXIT', Pid, Reason}, State) ->
     #state{worker_pid=WorkerPid} = State,
     case {Reason, Pid} of
         {normal, _} ->
+            %% Worker process exited normally
+            %% Stop this worker and check is there any other alive worker
+            basho_bench_terminator:worker_stopping(WorkerPid),
             {stop, normal, State};
         {_, WorkerPid} ->
             ?ERROR("Worker ~p exited with ~p~n", [Pid, Reason]),

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -26,7 +26,8 @@
 %% API
 -export([start_link/0,
          workers/0,
-         stop_child/1]).
+         stop_child/1,
+         active_workers/0]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -45,6 +46,9 @@ workers() ->
 
 stop_child(Id) ->
     supervisor:terminate_child(?MODULE, Id).
+
+active_workers() ->
+    [X || X <- workers(), X =/= undefined].
 
 
 %% ===================================================================


### PR DESCRIPTION
Rename basho_bench_duration module to basho_bench_terminator
This module will check whether to exit besho_bench, exit conditions
    1. run out of duration time
    2. run out of operations even if the duration time had not up
