### PR TITLE
Erlang 18 changes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,12 @@
-{require_otp_vsn, "R16|17"}.
+{require_otp_vsn, "R16|17|18"}.
 
 {deps,
  [
-  {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", "fbb7bc83806520ffef84107c85f53c1f7113c20d"}},
+  %% Workaround to enable R18 
+  %%  {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", "fbb7bc83806520ffef84107c85f53c1f7113c20d"}},
+  %%  Master has dependence on on meck 0.8.2 (only used in folsom testing) which fails under R18
+  %%  Branch uses {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}
+  {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", {branch, "64114-support-erlang-r18-folsom"}}},
   {lager, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-lager.git", {branch, "master"}}},
   {getopt, ".*",
    {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},


### PR DESCRIPTION
Once more with gusto  - modify rebar to allow 18 and use a branched version of folsom 
