### PR TITLE
Configurable basho_bench_duration:run timeout

### DIFF
--- a/src/basho_bench.app.src
+++ b/src/basho_bench.app.src
@@ -88,6 +88,9 @@
         %%
         {value_generator, {fixed_bin, 100}},
 
-        {shutdown_timeout, 30000}
+        {shutdown_timeout, 30000},
+
+        % milliseconds to wait during basho_bench_duration:run
+        {duration_call_run_timeout, 5000}
     ]}
 ]}.

--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -35,7 +35,8 @@
 
 
 run() ->
-    gen_server:call(?MODULE, run).
+    Timeout = basho_bench_config:get(duration_call_run_timeout),
+    gen_server:call(?MODULE, run, Timeout).
 
 
 remaining() ->


### PR DESCRIPTION
https://cloudant.fogbugz.com/f/cases/68092/

Here I make the `gen_server:call/3` timeout configurable for `basho_bench_duration:run/0`

I was hitting the default, 5s, during sharded ets operations with 1000 workers.
