### PR TITLE
Enable eprof profiling using config option

### DIFF
--- a/src/basho_bench_app.erl
+++ b/src/basho_bench_app.erl
@@ -83,10 +83,6 @@ start(_StartType, _StartArgs) ->
 
 
 stop(_State) ->
-    %% intentionally left in to show where worker profiling start/stop calls go.
-    %% eprof:stop_profiling(),
-    %% eprof:analyze(total),
-    %% eprof:log("bb.eprof"),
     ok.
 
 %% ===================================================================

--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -102,6 +102,17 @@ terminate(Reason, #state{duration=DurationMins}) ->
             end
     end,
     run_hook(basho_bench_config:get(post_hook, no_op)),
+    case basho_bench_config:get(enable_eprof, false) of 
+        false ->
+            ok;
+        true ->
+            ?CONSOLE("Stopping eprof profiling", []),
+            EprofFile = filename:join(basho_bench:get_test_dir(), "eprof.log"),
+            eprof:stop_profiling(),
+            eprof:log(EprofFile),
+            eprof:analyze(total),
+            ?CONSOLE("Eprof output in ~p\n", [EprofFile])
+    end,
     supervisor:terminate_child(basho_bench_sup, basho_bench_run_sup),
     case Reason of
         {shutdown, normal} ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -59,9 +59,14 @@ init([]) ->
     %% Get the number concurrent workers we're expecting and generate child
     %% specs for each
 
-    %% intentionally left in to show where worker profiling start/stop calls go.
-    %% eprof:start(),
-    %% eprof:start_profiling([self()]),
+    case basho_bench_config:get(enable_eprof, false) of 
+        false ->
+            ok;
+        true ->
+            ?CONSOLE("Starting eprof profiling\n", []),
+            {ok, _Pid} = eprof:start(),
+            profiling = eprof:start_profiling([self()])
+    end,
 
     Workers = worker_specs(basho_bench_config:get(concurrent), []),
     {ok, {{one_for_one, 5, 10}, Workers}}.


### PR DESCRIPTION
Make it easy to activate eprof profiling using a basho config param in support of pluggable storage engine diagnostics. 

Bugzid 66882
