### PR TITLE
82970 Support for multiple workers

### DIFF
--- a/src/basho_bench_config.erl
+++ b/src/basho_bench_config.erl
@@ -28,21 +28,38 @@
 -compile(export_all).
 -endif.
 
--export([load/1,
-         normalize_ips/2,
-         set/2,
-         get/1, get/2]).
+-export([
+    get/1,
+    get/2,
+    load/1,
+    normalize_ips/2,
+    set/2,
+    set_local_config/1
+]).
 
 -export([start_link/0]).
 
 % Gen server callbacks
--export([code_change/3, init/1, terminate/2, handle_call/3, handle_cast/2, handle_info/2]).
+-export([
+    code_change/3,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    init/1,
+    terminate/2
+]).
+
 
 -include("basho_bench.hrl").
 
--record(basho_bench_config_state, {}).
 
--type state() :: #basho_bench_config_state{}.
+-record(config_state, {
+    workers
+}).
+
+
+-type state() :: #config_state{}.
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -51,6 +68,7 @@
 ensure_started() -> 
     start_link().
 
+
 start_link() ->
     gen_server:start_link({global, ?MODULE}, ?MODULE, [], []).
 
@@ -58,25 +76,57 @@ start_link() ->
 load(Files) ->
     ensure_started(),
     gen_server:call({global, ?MODULE}, {load_files, Files}). 
-    
+
+
 set(Key, Value) ->
     gen_server:call({global, ?MODULE}, {set, Key, Value}).
 
+
 get(Key) ->
-    case gen_server:call({global, ?MODULE}, {get, Key}) of
-        {ok, Value} ->
-            Value;
+    case get_local_config(Key) of
         undefined ->
-            erlang:error("Missing configuration key", [Key])
+            case get_global_config(Key) of
+                {ok, Value} ->
+                    Value;
+                undefined ->
+                    erlang:error("Missing configuration key", [Key])
+            end;
+        {ok, Value} ->
+            Value
     end.
 
+
 get(Key, Default) ->
-    case gen_server:call({global, ?MODULE}, {get, Key}) of
-        {ok, Value} ->
-            Value;
+    case get_local_config(Key) of
         undefined ->
-            Default
+            case get_global_config(Key) of
+                {ok, Value} ->
+                    Value;
+                undefined ->
+                    Default
+            end;
+        {ok, Value} ->
+            Value
     end.
+
+
+set_local_config(LocalConfig) when is_list(LocalConfig) ->
+    Map = map_from_list(LocalConfig),
+    set_local_config(Map);
+set_local_config(LocalConfig) when is_map(LocalConfig) ->
+    erlang:put(local_config, LocalConfig).
+
+
+%% TODO: Change to maps:from_list(List) in Erlang 18
+map_from_list(List) ->
+    map_from_list(List, #{}).
+
+
+map_from_list([], Map) ->
+    Map;
+map_from_list([{K, V} | Rest], Map) ->
+    map_from_list(Rest, maps:put(K, V, Map)).
+
 
 %% @doc Normalize the list of IPs and Ports.
 %%
@@ -89,18 +139,35 @@ get(Key, Default) ->
 %%     {"127.0.0.1", 8092},
 %%     {"127.0.0.1", 8093}]
 normalize_ips(IPs, DefultPort) ->
-    F = fun(Entry, Acc) ->
+    lists:foldl(
+        fun(Entry, Acc) ->
                 normalize_ip_entry(Entry, Acc, DefultPort)
-        end,
-    lists:foldl(F, [], IPs).
-
-
-
+        end, [], IPs).
 
 
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+
+get_local_config(Key) ->
+    get_local_config(Key, undefined).
+
+
+get_local_config(Key, Default) ->
+    case erlang:get(local_config) of
+        undefined ->
+            Default;
+        Conf ->
+            case maps:get(Key, Conf, undefined) of
+                undefined -> Default;
+                Value -> {ok, Value}
+            end
+    end.
+
+
+get_global_config(Key) ->
+    gen_server:call({global, ?MODULE}, {get, Key}).
 
 
 normalize_ip_entry({IP, Ports}, Normalized, _) when is_list(Ports) ->
@@ -117,44 +184,53 @@ normalize_ip_entry(IP, Normalized, DefaultPort) ->
 
 -spec init(term()) -> {ok, state()}.  
 init(_Args) ->
-    State = #basho_bench_config_state{},
+    State = #config_state{ workers=[]},
     {ok, State}.
+
 
 -spec code_change(term(), state(), term()) -> {ok, state()}.
 code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.                                
+    {ok, State}.
+
 
 -spec terminate(term(), state()) -> 'ok'.
 terminate(_Reason, _State) ->
     ok.
 
+
 handle_call({load_files, FileNames}, _From, State) ->
     set_keys_from_files(FileNames),
     {reply, ok, State};
 
+
 handle_call({set, Key, Value}, _From, State) ->
     application:set_env(basho_bench, Key, Value), 
     {reply, ok, State};
+
 handle_call({get, Key}, _From, State) ->
     Value = application:get_env(basho_bench, Key),
     {reply, Value, State}.
 
+
 handle_cast(_Cast, State) ->
     {noreply, State}.
+
 
 handle_info(_Info, State) ->
     {noreply, State}.
 
+
 set_keys_from_files(Files) ->
-    KVs = [ 
-    case file:consult(File) of
-        {ok, Terms} ->
-            Terms;
-        {error, Reason} ->
-            ?FAIL_MSG("Failed to parse config file ~s: ~p\n", [File, Reason]),
-            throw(invalid_config),
-            notokay
-    end || File <- Files ],
+    KVs = lists:map(
+        fun(File) ->
+            case file:consult(File) of
+                {ok, Terms} ->
+                    Terms;
+                {error, Reason} ->
+                    ?FAIL_MSG("Failed to parse config file ~s: ~p\n", [File, Reason]),
+                    throw(invalid_config),
+                    notokay
+           end
+	end, Files),
     FlatKVs = lists:flatten(KVs),
     [application:set_env(basho_bench, Key, Value) || {Key, Value} <- FlatKVs].
-

--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -102,7 +102,7 @@ new({partitioned_sequential_int, StartKey, NumKeys}, Id)
     Ref = make_ref(),
     DisableProgress =
         basho_bench_config:get(disable_sequential_int_progress_report, false),
-    ?DEBUG("ID ~p generating range ~p to ~p\n", [Id, MinValue, MaxValue]),
+    ?DEBUG("ID ~p generating range ~p to ~p for ~p workers sharing keygen\n", [Id, MinValue, MaxValue, Workers]),
     fun() -> sequential_int_generator(Ref, MaxValue - MinValue, Id, DisableProgress) + MinValue end;
 new({uniform_int, MaxKey}, _Id)
   when is_integer(MaxKey), MaxKey > 0 ->
@@ -142,7 +142,7 @@ new({file_line_bin, Path, DoRepeat}, Id) ->
                     Chomped
             end,
     Loop = fun(L, FH) ->
-                   {Line, FH2}  = case file:read_line(FH) of
+                   {Line, FH2} = case file:read_line(FH) of
                                       {ok, LineBin} ->
                                           {Chomp(LineBin), FH};
                                       eof when DoRepeat /= repeat ->

--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -24,10 +24,11 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/2,
-         start_link_local/2,
+-export([start_link/3,
+         start_link_local/3,
          run/1,
-         stop/1]).
+         stop/1
+]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -42,6 +43,8 @@
                  driver,
                  driver_state,
                  api_pass_state,
+                 worker_type,
+                 local_config,
                  shutdown_on_error,
                  ops,
                  ops_len,
@@ -56,20 +59,20 @@
 %% API
 %% ====================================================================
 
-start_link(SupChild, Id) ->
-    case basho_bench_config:get(distribute_work, false) of 
-        true -> 
-            start_link_distributed(SupChild, Id);
-        false -> 
-            start_link_local(SupChild, Id)
+start_link(SupChild, Id, WorkerConf) ->
+    case basho_bench_config:get(distribute_work, false) of
+        true ->
+            start_link_distributed(SupChild, Id, WorkerConf);
+        false ->
+            start_link_local(SupChild, Id, WorkerConf)
     end.
 
-start_link_distributed(SupChild, Id) ->
+start_link_distributed(SupChild, Id, WorkerConf) ->
     Node = pool:get_node(),
-    rpc:block_call(Node, ?MODULE, start_link_local, [SupChild, Id]).
+    rpc:block_call(Node, ?MODULE, start_link_local, [SupChild, Id, WorkerConf]).
 
-start_link_local(SupChild, Id) ->
-    gen_server:start_link(?MODULE, [SupChild, Id], []).
+start_link_local(SupChild, Id, WorkerConf) ->
+    gen_server:start_link(?MODULE, [SupChild, Id, WorkerConf], []).
 
 run(Pids) ->
     [ok = gen_server:call(Pid, run, infinity) || Pid <- Pids],
@@ -83,7 +86,10 @@ stop(Pids) ->
 %% gen_server callbacks
 %% ====================================================================
 
-init([SupChild, Id]) ->
+init([SupChild, {WorkerType, WorkerId, WorkerGlobalId}=Id, WorkerConf]) ->
+    %% Set local worker config here and for subprocess during worker_init
+    basho_bench_config:set_local_config(WorkerConf),
+
     %% Setup RNG seed for worker sub-process to use; incorporate the ID of
     %% the worker to ensure consistency in load-gen
     %%
@@ -99,23 +105,27 @@ init([SupChild, Id]) ->
             now -> now()
         end,
 
-    RngSeed = {A1+Id, A2+Id, A3+Id},
+    RngSeed = {A1 + WorkerGlobalId, A2 + WorkerGlobalId, A3 + WorkerGlobalId},
 
     %% Pull all config settings from environment
-    Driver  = basho_bench_config:get(driver),
-    Ops     = ops_tuple(),
+    Driver = basho_bench_config:get(driver),
+    Operations = basho_bench_config:get(operations),
+    Ops = ops_tuple(Operations),
     ShutdownOnError = basho_bench_config:get(shutdown_on_error, false),
 
     %% Check configuration for flag enabling new API that passes opaque State object to support accessor functions
-
-    State0 = #state { id = Id, 
+    State0 = #state { id = Id,
                      api_pass_state = basho_bench_config:get(api_pass_state),
                      driver = Driver,
+                     local_config = WorkerConf,
+                     worker_type = WorkerType,
                      shutdown_on_error = ShutdownOnError,
-                     ops = Ops, ops_len = size(Ops),
+                     ops = Ops,
+                     ops_len = size(Ops),
                      rng_seed = RngSeed,
                      parent_pid = self(),
-                     sup_id = SupChild},
+                     sup_id = SupChild
+                     },
 
     %% Finally, initialize key and value generation. We pass in our ID to the
     %% initialization to enable (optional) key/value space partitioning
@@ -148,7 +158,6 @@ init([SupChild, Id]) ->
         false ->
             ok
     end,
-
     {ok, State#state { worker_pid = WorkerPid }}.
 
 handle_call(run, _From, State) ->
@@ -180,8 +189,6 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-
-
 %% ====================================================================
 %% Internal functions
 %% ====================================================================
@@ -189,21 +196,24 @@ code_change(_OldVsn, State, _Extra) ->
 %%
 %% Expand operations list into tuple suitable for weighted, random draw
 %%
-ops_tuple() ->
+ops_tuple(Operations) ->
     F =
         fun({OpTag, Count}) ->
                 lists:duplicate(Count, {OpTag, OpTag});
            ({Label, OpTag, Count}) ->
+                lists:duplicate(Count, {Label, OpTag});
+           ({Label, OpTag, Count, _OptionsList}) ->
                 lists:duplicate(Count, {Label, OpTag})
         end,
-    Ops = [F(X) || X <- basho_bench_config:get(operations, [])],
+    Ops = [F(X) || X <- Operations],
     list_to_tuple(lists:flatten(Ops)).
-
 
 worker_init(State) ->
     %% Trap exits from linked parent process; use this to ensure the driver
     %% gets a chance to cleanup
     process_flag(trap_exit, true),
+    %% Publish local config into worker subprocess
+    basho_bench_config:set_local_config(State#state.local_config),
     random:seed(State#state.rng_seed),
     worker_idle_loop(State).
 
@@ -212,11 +222,11 @@ worker_idle_loop(State) ->
     receive
         {init_driver, Caller} ->
             %% Spin up the driver implementation, optionally support new approach of passing State
-            DriverNew = case State#state.api_pass_state of 
+            DriverNew = case State#state.api_pass_state of
                     false -> catch(Driver:new(State#state.id));
                      _ -> catch(Driver:new(State#state.id, State))
                 end,
-            case DriverNew of 
+            case DriverNew of
                 {ok, DriverState} ->
                     Caller ! driver_ready,
                     ok;
@@ -243,20 +253,25 @@ worker_idle_loop(State) ->
             end
     end.
 
+%% Traditional call to run/4 passing OpTag, keygen, valgen, and driver state
 worker_next_op2(#state{api_pass_state=false}=State, OpTag) ->
     catch (State#state.driver):run(OpTag, State#state.keygen, State#state.valgen,State#state.driver_state);
+%% When using api_pass_state, call run/3 passing Optag, driver state and worker state,
+%% then use accessors to get_keygen or get_valgen using State
 worker_next_op2(State, OpTag) ->
-   catch (State#state.driver):run(OpTag, State#state.driver_state, State).
+    catch (State#state.driver):run(OpTag, State#state.driver_state, State).
 
 worker_next_op(State) ->
-    Next = element(random:uniform(State#state.ops_len), State#state.ops),
-    {_Label, OpTag} = Next,
+    {Label, OpTag} = element(random:uniform(State#state.ops_len), State#state.ops),
     Start = os:timestamp(),
     Result = worker_next_op2(State, OpTag),
     ElapsedUs = erlang:max(0, timer:now_diff(os:timestamp(), Start)),
+
+    OpName = { basho_bench_stats:worker_op_name(State#state.worker_type, Label),
+               basho_bench_stats:worker_op_name(State#state.worker_type, OpTag)},
     case Result of
         {Res, DriverState} when Res == ok orelse element(1, Res) == ok ->
-            basho_bench_stats:op_complete(Next, Res, ElapsedUs),
+            basho_bench_stats:op_complete(OpName, Res, ElapsedUs),
             {ok, State#state { driver_state = DriverState}};
 
         {Res, DriverState} when Res == silent orelse element(1, Res) == silent ->
@@ -264,12 +279,12 @@ worker_next_op(State) ->
 
         {ok, ElapsedT, DriverState} ->
             %% time is measured by external system
-            basho_bench_stats:op_complete(Next, ok, ElapsedT),
+            basho_bench_stats:op_complete(OpName, ok, ElapsedT),
             {ok, State#state { driver_state = DriverState}};
 
         {error, Reason, DriverState} ->
             %% Driver encountered a recoverable error
-            basho_bench_stats:op_complete(Next, {error, Reason}, ElapsedUs),
+            basho_bench_stats:op_complete(OpName, {error, Reason}, ElapsedUs),
             State#state.shutdown_on_error andalso
                 erlang:send_after(500, basho_bench,
                                   {shutdown, "Shutdown on errors requested", 1}),
@@ -278,7 +293,7 @@ worker_next_op(State) ->
         {'EXIT', Reason} ->
             %% Driver crashed, generate a crash error and terminate. This will take down
             %% the corresponding worker which will get restarted by the appropriate supervisor.
-            basho_bench_stats:op_complete(Next, {error, crash}, ElapsedUs),
+            basho_bench_stats:op_complete(OpName, {error, crash}, ElapsedUs),
 
             %% Give the driver a chance to cleanup
             (catch (State#state.driver):terminate({'EXIT', Reason}, State#state.driver_state)),
@@ -351,9 +366,11 @@ rate_worker_run_loop(State, Lambda) ->
             exit(ExitReason)
     end.
 
-add_generators(#state{api_pass_state = ApiPassState,id=Id}=State) ->
-    KeyGen = init_generators(ApiPassState, basho_bench_config:get(key_generator), Id, basho_bench_keygen),
-    ValGen = init_generators(ApiPassState, basho_bench_config:get(value_generator), Id, basho_bench_valgen),
+add_generators(#state{api_pass_state=ApiPassState, id=Id}=State) ->
+    {_WorkerType, WorkerId, _WorkerGlobalId} = Id,
+    % KeyGen needs to know WorkerId within a WorkerType (local concurrent) number of workers sharing a thread
+    KeyGen = init_generators(ApiPassState, basho_bench_config:get(key_generator), WorkerId, basho_bench_keygen),
+    ValGen = init_generators(ApiPassState, basho_bench_config:get(value_generator), WorkerId, basho_bench_valgen),
     State#state{keygen=KeyGen, valgen=ValGen}.
 
 %% Not passing state API - expect non-list spec or error during new attempt


### PR DESCRIPTION
Basic working version of multi-worker config support plus some cleanups 

1. basho_bench_worker_sup
* now looks for WorkerTypes (named configs for different drivers with local configs) and Workers (specifies numbers of workers of each type (equivalent to concurrent). 
* generates worker start_link commands with triplet ID (WorkerType, WorkerId (within worker type) and GlobalId (unique number for every worker) and copy of worker-type config as LocalConfig. (Just noticed how ugly "GlobalId" is)
* Continues to support original non-worker style configs but marks these with WorkerType = no_workers

2. basho_bench_worker
* handles new start_link/3 format supporting triplet ID and localconfig
* init handles new triplet ID and local config, saves config into process dictionary through basho_bench_config
* includes OptionsConfigs (STILL THINKING ABOUT)
* changes in worker_next_op2 calls

3. basho_bench_stats
* changes in getting name/op information for statistics that recognizes worker type extended names
* cleanups

4. basho_bench_config
* support storing local_config into process dictionary using set_local_config and searching using modified versions of get
* cleanups, renamed state