### PR TITLE
enable log level

### DIFF
--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -43,7 +43,8 @@ setup_benchmark(Opts, Configs) ->
     TestDir = test_dir(Opts, BenchName),
     application:set_env(basho_bench, test_dir, TestDir),
     basho_bench_config:set(test_id, BenchName),
-    ConsoleLagerLevel = application:get_env(basho_bench, log_level, debug),
+    ConsoleLagerLevel = application:get_env(basho_bench, level, debug),
+
     ErrorLog = filename:join([TestDir, "error.log"]),
     ConsoleLog = filename:join([TestDir, "console.log"]),
     CrashLog = filename:join([TestDir, "crash.log"]),
@@ -62,10 +63,6 @@ setup_benchmark(Opts, Configs) ->
     application:set_env(lager, crash_log, CrashLog),
     load_apps([lager, basho_bench]),
     lager:start(),
-    %% Log level can be overriden by the config files
-    CustomLagerLevel = basho_bench_config:get(log_level, debug),
-    lager:set_loglevel(lager_console_backend, CustomLagerLevel),
-    lager:set_loglevel(lager_file_backend, ConsoleLog, CustomLagerLevel),
     case basho_bench_config:get(distribute_work, false) of
         true -> setup_distributed_work();
         false -> ok
@@ -87,7 +84,10 @@ setup_benchmark(Opts, Configs) ->
     %% Make sure this happens after starting lager or failures wont
     %% show.
     basho_bench_config:load(Configs),
-
+    %% Log level can be overriden by the config files
+    CustomLagerLevel = basho_bench_config:get(level, info),
+    lager:set_loglevel(lager_console_backend, CustomLagerLevel),
+    lager:set_loglevel(lager_file_backend, ConsoleLog, CustomLagerLevel),
     %% Copy the config into the test dir for posterity
     [ begin {ok, _} = file:copy(Config, filename:join(TestDir, filename:basename(Config))) end
       || Config <- Configs ],


### PR DESCRIPTION
This PR will fix a bug that log level couldn't be overwritten in basho_bench_config file.

Changed: 

- Log level can be overridden by the config files

  BugzID: 85978