### PR TITLE
Maybe support Erlang 18+, update deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,23 +7,19 @@
   %%  Master has dependence on on meck 0.8.2 (only used in folsom testing) which fails under R18
   %%  Branch uses {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}
   {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", {branch, "64114-support-erlang-r18-folsom"}}},
-  {lager, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-lager.git", {branch, "master"}}},
-  {getopt, ".*",
-   {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},
-  {ibrowse, ".*", {git, "https://github.com/cloudant/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},
+  {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},
+  {ibrowse, ".*", {git, "https://github.com/apache/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},
   {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}},
   {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.14.7"}}}
  ]}.
 
-{erl_opts, [{src_dirs, [src]},
-           {parse_transform, lager_transform}]}.
+{erl_opts, [{src_dirs, [src]}]}.
 
 {escript_incl_apps, [
     bear,
     folsom,
     getopt,
     goldrush,
-    lager,
     ibrowse,
     jiffy
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,12 +8,13 @@
   %%  Branch uses {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}
   {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", {branch, "64114-support-erlang-r18-folsom"}}},
   {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},
+  {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.6.8"}}},
   {ibrowse, ".*", {git, "https://github.com/apache/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},
   {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}},
   {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.14.7"}}}
  ]}.
 
-{erl_opts, [{src_dirs, [src]}]}.
+{erl_opts, [{src_dirs, [src]}, {parse_transform, lager_transform}]}.
 
 {escript_incl_apps, [
     bear,
@@ -21,7 +22,8 @@
     getopt,
     goldrush,
     ibrowse,
-    jiffy
+    jiffy,
+    lager
 ]}.
 
 %% The value of +Q here is for 1.2 million ports, but the process

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
-{require_otp_vsn, "R16|17|18"}.
+{require_otp_vsn, "18|19|20|21"}.
 
 {deps,
  [
-  %% Workaround to enable R18 
+  %% Workaround to enable R18
   %%  {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", "fbb7bc83806520ffef84107c85f53c1f7113c20d"}},
   %%  Master has dependence on on meck 0.8.2 (only used in folsom testing) which fails under R18
   %%  Branch uses {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "18|19|20|21"}.
+{require_otp_vsn, "17|18|19|20|21"}.
 
 {deps,
  [


### PR DESCRIPTION
Drop support for old versions, allow new versions. Of course we will encounter challenges as we seek to build against newer versions.

Update our dependencies and drop lager as well, because it has been retired in CouchDB. This remains to be proven -- we may still require lager and need to update to [a more recent version](https://github.com/erlang-lager/lager/releases).