### PR TITLE
use rand module instead of random

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
   %%  {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", "fbb7bc83806520ffef84107c85f53c1f7113c20d"}},
   %%  Master has dependence on on meck 0.8.2 (only used in folsom testing) which fails under R18
   %%  Branch uses {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}
-  {folsom, ".*", {git, "https://github.com/cloudant/couchdb-folsom.git", {branch, "64114-support-erlang-r18-folsom"}}},
+  {folsom, ".*", {git, "https://github.com/apache/couchdb-folsom.git", {tag, "CouchDB-0.8.3"}}},
   {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},
   {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.6.8"}}},
   {ibrowse, ".*", {git, "https://github.com/apache/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -62,7 +62,7 @@ setup_benchmark(Opts) ->
     CustomLagerLevel = basho_bench_config:get(log_level, debug),
     lager:set_loglevel(lager_console_backend, CustomLagerLevel),
     lager:set_loglevel(lager_file_backend, ConsoleLog, CustomLagerLevel),
-    case basho_bench_config:get(distribute_work, false) of 
+    case basho_bench_config:get(distribute_work, false) of
         true -> setup_distributed_work();
         false -> ok
     end,
@@ -272,8 +272,8 @@ get_addr_args() ->
     StrAddrs = [inet:ntoa(Addr) || Addr <- Addrs],
     string:join(StrAddrs, " ").
 setup_distributed_work() ->
-    case node() of 
-        'nonode@nohost' -> 
+    case node() of
+        'nonode@nohost' ->
             ?STD_ERR("Basho bench not started in distributed mode, and distribute_work = true~n", []),
             halt(1);
         _ -> ok
@@ -296,8 +296,8 @@ setup_distributed_work() ->
 
 
 deploy_module(Module) ->
-    case basho_bench_config:get(distribute_work, false) of 
-        true -> 
+    case basho_bench_config:get(distribute_work, false) of
+        true ->
             Nodes = nodes(),
             {Module, Binary, Filename} = code:get_object_code(Module),
             rpc:multicall(Nodes, code, load_binary, [Module, Filename, Binary]);
@@ -314,28 +314,22 @@ distribute_app(App) ->
     EbinsDir = lists:filter(fun(CodePathDir) -> string:substr(CodePathDir, 1, LibDirLen) ==  LibDir end, code:get_path()),
     StripEndFun = fun(Path) ->
         PathLen = string:len(Path),
-        case string:substr(Path, PathLen - string:len(CodeExtension) + 1, string:len(Path)) of 
+        case string:substr(Path, PathLen - string:len(CodeExtension) + 1, string:len(Path)) of
             CodeExtension ->
                 {true, string:substr(Path, 1, PathLen - string:len(CodeExtension))};
             _ -> false
         end
-    end, 
+    end,
     EbinDirDistributeFun = fun(EbinDir) ->
         {ok, Beams} = erl_prim_loader:list_dir(EbinDir),
         Modules = lists:filtermap(StripEndFun, Beams),
         ModulesLoaded = [code:load_abs(filename:join(EbinDir, ModFileName)) || ModFileName <- Modules],
         lists:foreach(fun({module, Module}) -> deploy_module(Module) end, ModulesLoaded)
     end,
-    lists:foreach(EbinDirDistributeFun, EbinsDir),    
+    lists:foreach(EbinDirDistributeFun, EbinsDir),
     ok.
-%% just a utility, should be in basho_bench_utils.erl
-%% but 's' is for multiple utilities, and so far this
-%% is the only one.
--ifdef(new_hash).
+
 md5(Bin) -> crypto:hash(md5, Bin).
--else.
-md5(Bin) -> crypto:md5(Bin).
--endif.
 
 load_apps([]) ->
     ok;

--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -106,10 +106,10 @@ new({partitioned_sequential_int, StartKey, NumKeys}, Id)
     fun() -> sequential_int_generator(Ref, MaxValue - MinValue, Id, DisableProgress) + MinValue end;
 new({uniform_int, MaxKey}, _Id)
   when is_integer(MaxKey), MaxKey > 0 ->
-    fun() -> random:uniform(MaxKey) end;
+    fun() -> rand:uniform(MaxKey) end;
 new({uniform_int, StartKey, NumKeys}, _Id)
   when is_integer(StartKey), is_integer(NumKeys), NumKeys > 0 ->
-    fun() -> random:uniform(NumKeys) + StartKey - 1 end;
+    fun() -> rand:uniform(NumKeys) + StartKey - 1 end;
 new({pareto_int, MaxKey}, _Id)
   when is_integer(MaxKey), MaxKey > 0 ->
     pareto(trunc(MaxKey * 0.2), ?PARETO_SHAPE);
@@ -226,7 +226,7 @@ pareto(Mean, Shape) ->
     S1 = (-1 / Shape),
     S2 = Mean * (Shape - 1),
     fun() ->
-            U = 1 - random:uniform(),
+            U = 1 - rand:uniform(),
             trunc((math:pow(U, S1) - 1) * S2)
     end.
 

--- a/src/basho_bench_stats.erl
+++ b/src/basho_bench_stats.erl
@@ -55,7 +55,7 @@ start_link() ->
     gen_server:start_link({global, ?MODULE}, ?MODULE, [], []).
 
 exponential(Lambda) ->
-    -math:log(random:uniform()) / Lambda.
+    -math:log(rand:uniform()) / Lambda.
 
 run() ->
     gen_server:call({global, ?MODULE}, run).

--- a/src/basho_bench_valgen.erl
+++ b/src/basho_bench_valgen.erl
@@ -40,7 +40,7 @@ new({fixed_bin, Size, Val}, _Id)
     fun() -> Data end;
 new({fixed_char, Size}, _Id)
   when is_integer(Size), Size >= 0 ->
-    fun() -> list_to_binary(lists:map(fun (_) -> random:uniform(95)+31 end, lists:seq(1,Size))) end;
+    fun() -> list_to_binary(lists:map(fun (_) -> rand:uniform(95)+31 end, lists:seq(1,Size))) end;
 new({exponential_bin, MinSize, Mean}, Id)
   when is_integer(MinSize), MinSize >= 0, is_number(Mean), Mean > 0 ->
     Source = init_source(Id),
@@ -49,7 +49,7 @@ new({uniform_bin, MinSize, MaxSize}, Id)
   when is_integer(MinSize), is_integer(MaxSize), MinSize < MaxSize ->
     Source = init_source(Id),
     Diff = MaxSize - MinSize,
-    fun() -> data_block(Source, MinSize + random:uniform(Diff)) end;
+    fun() -> data_block(Source, MinSize + rand:uniform(Diff)) end;
 new({function, Module, Function, Args}, Id)
   when is_atom(Module), is_atom(Function), is_list(Args) ->
     case code:ensure_loaded(Module) of
@@ -60,10 +60,10 @@ new({function, Module, Function, Args}, Id)
     end;
 new({uniform_int, MaxVal}, _Id)
   when is_integer(MaxVal), MaxVal >= 1 ->
-    fun() -> random:uniform(MaxVal) end;
+    fun() -> rand:uniform(MaxVal) end;
 new({uniform_int, MinVal, MaxVal}, _Id)
   when is_integer(MinVal), is_integer(MaxVal), MaxVal > MinVal ->
-    fun() -> random:uniform(MinVal, MaxVal) end;
+    fun() -> rand:uniform(MinVal, MaxVal) end;
 new(Other, _Id) ->
     ?FAIL_MSG("Invalid value generator requested: ~p\n", [Other]).
 
@@ -86,7 +86,7 @@ init_source(Id) ->
 init_source(1, undefined) ->
     SourceSz = basho_bench_config:get(?VAL_GEN_SRC_SIZE, 96*1048576),
     ?INFO("Random source: calling crypto:rand_bytes(~w) (override with the '~w' config option\n", [SourceSz, ?VAL_GEN_SRC_SIZE]),
-    Bytes = crypto:rand_bytes(SourceSz),
+    Bytes = crypto:strong_rand_bytes(SourceSz),
     try
         ?TAB = ets:new(?TAB, [public, named_table]),
         true = ets:insert(?TAB, {x, Bytes})
@@ -107,7 +107,7 @@ init_source(Id, Path) ->
 data_block({SourceCfg, SourceSz, Source}, BlockSize) ->
     case SourceSz - BlockSize > 0 of
         true ->
-            Offset = random:uniform(SourceSz - BlockSize),
+            Offset = rand:uniform(SourceSz - BlockSize),
             <<_:Offset/bytes, Slice:BlockSize/bytes, _Rest/binary>> = Source,
             Slice;
         false ->

--- a/src/basho_bench_worker.erl
+++ b/src/basho_bench_worker.erl
@@ -217,7 +217,7 @@ worker_init(State) ->
     process_flag(trap_exit, true),
     %% Publish local config into worker subprocess
     basho_bench_config:set_local_config(State#state.local_config),
-    random:seed(State#state.rng_seed),
+    rand:seed(exs64, State#state.rng_seed),
     worker_idle_loop(State).
 
 worker_idle_loop(State) ->
@@ -281,7 +281,7 @@ worker_next_op2(State, OpTag) ->
     end.
 
 worker_next_op(State) ->
-    {Label, OpTag} = element(random:uniform(State#state.ops_len), State#state.ops),
+    {Label, OpTag} = element(rand:uniform(State#state.ops_len), State#state.ops),
     Start = os:timestamp(),
     Result = worker_next_op2(State, OpTag),
     ElapsedUs = erlang:max(0, timer:now_diff(os:timestamp(), Start)),

--- a/src/basho_uuid.erl
+++ b/src/basho_uuid.erl
@@ -33,7 +33,7 @@
 
 % Generates a random binary UUID.
 v4() ->
-  v4(random:uniform(round(math:pow(2, 48))) - 1, random:uniform(round(math:pow(2, 12))) - 1, random:uniform(round(math:pow(2, 32))) - 1, random:uniform(round(math:pow(2, 30))) - 1).
+  v4(rand:uniform(round(math:pow(2, 48))) - 1, rand:uniform(round(math:pow(2, 12))) - 1, rand:uniform(round(math:pow(2, 32))) - 1, rand:uniform(round(math:pow(2, 30))) - 1).
 v4(R1, R2, R3, R4) ->
     <<R1:48, 4:4, R2:12, 2:2, R3:32, R4: 30>>.
 


### PR DESCRIPTION
we need upgrade perf stack to support erlang OTP version more than 19, so we need update our code to use

- `rand` module instead of `random` module 

- `crypto:strong_rand_bytes` instead of `crypto:rand_bytes`

- `crypto:hash(md5, Bin).` instead of `crypto:md5` 