### PR TITLE
fix a duration gen server crash error

### DIFF
--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -88,7 +88,8 @@ handle_info({'DOWN', Ref, process, _Object, Info}, #state{ref=Ref}=State) ->
 handle_info(timeout, State) ->
     {stop, {shutdown, normal}, State};
 
-handle_info(_Msg, State) ->
+handle_info(Msg, State) ->
+    ?WARN("basho_bench_duration handled unexpected info message: ~p", [Msg]),
     {noreply, State}.
 
 

--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -86,7 +86,10 @@ handle_info({'DOWN', Ref, process, _Object, Info}, #state{ref=Ref}=State) ->
     {stop, {shutdown, Info}, State};
 
 handle_info(timeout, State) ->
-    {stop, {shutdown, normal}, State}.
+    {stop, {shutdown, normal}, State};
+
+handle_info(_Msg, State) ->
+    {noreply, State}.
 
 
 terminate(Reason, #state{duration=DurationMins}) ->


### PR DESCRIPTION
This PR will fix a crash error when the duration get server is initializing.
when [this line](https://github.com/cloudant/basho_bench/blob/cloudant/src/basho_bench_duration.erl#L51) is invoked,
sometimes duration gen_server will receive a message neither `handle_info({'DOWN', Ref, process, _Object, Info}, #state{ref=Ref}=State) ` nor `handle_info(timeout, State)`, but like this message 
```
10:13:35.278 [info] debug _Msg: {#Ref<0.3640246646.1226571777.250739>,ready}, State: {state,#Ref<0.3640246646.1226571777.257576>,undefined,undefined}
10:13:35.278 [info] debug _Msg: {#Ref<0.3640246646.1226571777.253308>,ready}, State: {state,#Ref<0.3640246646.1226571777.257576>,undefined,undefined}
10:13:35.278 [info] debug _Msg: {#Ref<0.3640246646.1226571777.256376>,ready}, State: {state,#Ref<0.3640246646.1226571777.257576>,undefined,undefined}
```
this time gen_server will enter into the terminate function and call this https://github.com/cloudant/basho_bench/blob/cloudant/src/basho_bench_duration.erl#L106, then it crashed.
but this error is not always reproduced, but occasionally reproduced.

 I am not sure where from `{#Ref<0.3640246646.1226571777.250739>,ready}, State: {state,#Ref<0.3640246646.1226571777.257576>,undefined,undefined}` message is sent to duration gen_server, maybe this line:
https://github.com/cloudant/basho_bench/blob/cloudant/src/basho_bench_duration.erl#L52
