### PR TITLE
Clustering with bootstrap

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "17|18|19|20|21"}.
+{require_otp_vsn, "17|18|19|20|21|22"}.
 
 {deps,
  [

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -23,7 +23,7 @@
 
 -export([start/0]).
 
--export([setup_benchmark/1, run_benchmark/1, await_completion/1, main/1, md5/1, get_test_dir/0]).
+-export([setup_benchmark/2, run_benchmark/0, await_completion/1, main/1, md5/1, get_test_dir/0]).
 -export([master_node/0, node_count/0, is_master/0, is_worker/0, is_clustered/0]).
 -include("basho_bench.hrl").
 
@@ -35,7 +35,7 @@ start() ->
 %% API
 %% ====================================================================
 
-setup_benchmark(Opts) ->
+setup_benchmark(Opts, Configs) ->
     BenchName = bench_name(Opts),
     TestDir = test_dir(Opts, BenchName),
     application:set_env(basho_bench, test_dir, TestDir),
@@ -67,10 +67,7 @@ setup_benchmark(Opts) ->
         true -> setup_distributed_work();
         false -> ok
     end,
-    ok.
 
-
-run_benchmark(Configs) ->
     TestDir = get_test_dir(),
     %% Init code path
     add_code_paths(basho_bench_config:get(code_paths, [])),
@@ -94,6 +91,10 @@ run_benchmark(Configs) ->
 
     log_dimensions(),
 
+    ok.
+
+
+run_benchmark() ->
     basho_bench_sup:start_child(),
     case {master_node(), node_count()} of
         %% No master
@@ -138,8 +139,8 @@ main(Args) ->
     ok = maybe_net_node(Opts),
     ok = maybe_join(Opts),
     {ok, _} = start(),
-    setup_benchmark(Opts),
-    run_benchmark(Configs),
+    setup_benchmark(Opts, Configs),
+    run_benchmark(),
     await_completion(infinity).
 
 

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -373,27 +373,29 @@ get_test_dir() ->
     end.
 
 master_node() ->
+    Default = case init:get_argument(master_node) of
+        {ok, [[Node]]} -> list_to_atom(Node);
+        _ -> node()
+    end,
     case catch basho_bench_config:get(master_node, undefined) of
         {'EXIT', {noproc, _}} ->
-            case init:get_argument(master_node) of
-                {ok, [[Node]]} -> list_to_atom(Node);
-                _ -> node()
-            end;
+            Default;
         undefined ->
-            node();
+            Default;
         Res ->
             Res
     end.
 
 node_count() ->
+    Default = case init:get_argument(node_count) of
+        {ok, [[NodeCount]]} -> list_to_integer(NodeCount);
+        _ -> 1
+    end,
     case catch basho_bench_config:get(node_count, undefined) of
         {'EXIT', {noproc, _}} ->
-            case init:get_argument(node_count) of
-                {ok, [[NodeCount]]} -> list_to_integer(NodeCount);
-                _ -> 1
-            end;
+            Default;
         undefined ->
-            1;
+            Default;
         Res ->
             Res
     end.

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -376,6 +376,8 @@ master_node() ->
                 {ok, [[Node]]} -> list_to_atom(Node);
                 _ -> node()
             end;
+        undefined ->
+            node();
         Res ->
             Res
     end.
@@ -387,6 +389,8 @@ node_count() ->
                 {ok, [[NodeCount]]} -> list_to_integer(NodeCount);
                 _ -> 1
             end;
+        undefined ->
+            1;
         Res ->
             Res
     end.

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -28,6 +28,9 @@
 -include("basho_bench.hrl").
 
 
+-define(AWAIT_TIMEOUT, 10000).
+
+
 start() ->
     application:ensure_all_started(basho_bench).
 
@@ -414,13 +417,18 @@ await_nodes(NodeCount) ->
     await_nodes(NodeCount, 100).
 
 await_nodes(NodeCount, SleepMS) ->
+    await_nodes(NodeCount, SleepMS, ?AWAIT_TIMEOUT).
+
+await_nodes(_, _, Timeout) when Timeout < 0 ->
+    throw({error, await_node_timeout});
+await_nodes(NodeCount, SleepMS, Timeout) ->
     case NodeCount =:= length(nodes()) + 1 of
         true ->
             ok;
         false ->
             ?INFO("Waiting on ~p nodes to connect~n", [NodeCount - length(nodes()) - 1]),
             timer:sleep(SleepMS),
-            await_nodes(NodeCount, SleepMS * 2)
+            await_nodes(NodeCount, SleepMS * 2, Timeout - SleepMS)
     end.
 
 bootstrap_bb() ->

--- a/src/basho_bench.erl
+++ b/src/basho_bench.erl
@@ -401,19 +401,13 @@ node_count() ->
     end.
 
 is_master() ->
-    case master_node() =:= node() of
-        true -> true;
-        false -> false
-    end.
+    master_node() =:= node().
 
 is_worker() ->
     not is_master() and is_clustered().
 
 is_clustered() ->
-    case node_count() > 1 of
-        true -> true;
-        false -> false
-    end.
+    node_count() > 1.
 
 await_nodes(NodeCount) ->
     await_nodes(NodeCount, 100).

--- a/src/basho_bench_stats.erl
+++ b/src/basho_bench_stats.erl
@@ -65,7 +65,7 @@ op_complete(Op, ok, ElapsedUs) ->
 op_complete(Op, {ok, Units}, ElapsedUs) ->
     %% Update the histogram and units counter for the op in question
    % io:format("Get distributed: ~p~n", [get_distributed()]),
-    case get_distributed() of
+    case get_distributed() or basho_bench:is_worker() of
         true ->
             gen_server:cast({global, ?MODULE}, {Op, {ok, Units}, ElapsedUs});
         false ->

--- a/src/basho_bench_sup.erl
+++ b/src/basho_bench_sup.erl
@@ -48,4 +48,12 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    {ok, {{one_for_one, 5, 10}, [?CHILD(basho_bench_config, worker)]}}.
+    Children = case basho_bench:is_master() of
+        true ->
+            [?CHILD(basho_bench_config, worker)];
+        false ->
+            pong = net_adm:ping(basho_bench:master_node()),
+            global:sync(),
+            []
+    end,
+    {ok, {{one_for_one, 5, 10}, Children}}.

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -26,6 +26,8 @@
 %% API
 -export([start_link/0,
          workers/0,
+         workers/1,
+         remote_workers/1,
          stop_child/1,
          active_workers/0]).
 
@@ -42,7 +44,13 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 workers() ->
-    [Pid || {_Id, Pid, worker, [basho_bench_worker]} <- supervisor:which_children(?MODULE)].
+    workers(?MODULE).
+
+workers(Sup) ->
+    [Pid || {_Id, Pid, worker, [basho_bench_worker]} <- supervisor:which_children(Sup)].
+
+remote_workers(Node) ->
+    workers({?MODULE, Node}).
 
 stop_child(Id) ->
     supervisor:terminate_child(?MODULE, Id).


### PR DESCRIPTION
This PR adds a new distributed benchmarking mechanism by way of a master node and pool of workers. The master node is responsible for stats collection and spawning workers on all the nodes. This PR also does some rearranging of functionality in setup and run_benchmark to fully bootstrap everything in setup rather than run_benchmark partially completing setup related tasks.