### PR TITLE
Support worker counts in psi keygen

### DIFF
--- a/src/basho_bench_keygen.erl
+++ b/src/basho_bench_keygen.erl
@@ -91,9 +91,11 @@ new({sequential_int, MaxKey}, Id)
     fun() -> sequential_int_generator(Ref, MaxKey, Id, DisableProgress) end;
 new({partitioned_sequential_int, MaxKey}, Id) ->
     new({partitioned_sequential_int, 0, MaxKey}, Id);
-new({partitioned_sequential_int, StartKey, NumKeys}, Id)
-  when is_integer(StartKey), is_integer(NumKeys), NumKeys > 0 ->
+new({partitioned_sequential_int, StartKey, NumKeys}, Id) ->
     Workers = basho_bench_config:get(concurrent),
+    new({partitioned_sequential_int, StartKey, NumKeys, Workers}, Id);
+new({partitioned_sequential_int, StartKey, NumKeys, Workers}, Id)
+  when is_integer(StartKey), is_integer(NumKeys), NumKeys > 0 ->
     Range = NumKeys div Workers,
     MinValue = StartKey + Range * (Id - 1),
     MaxValue = StartKey +


### PR DESCRIPTION
The partitioned sequential int generator is currently dependent on global config to supply the number of workers in which to partition the data. This is obviously suboptimal in situations where you want to work independently of `basho_bench_config:get(concurrent)`. This allows for the specification of the number of partitions, while still maintaining the existing behavior of using the global config value by default.