### PR TITLE
Cloudant worker rampup

### DIFF
--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -28,7 +28,8 @@
 -record(state, {
     ref,
     duration,
-    start
+    start,
+    rampup_interval
 }).
 
 -include("basho_bench.hrl").
@@ -50,7 +51,7 @@ start_link() ->
 init([]) ->
     run_hook(basho_bench_config:get(pre_hook, no_op)),
     Ref = erlang:monitor(process, whereis(basho_bench_run_sup)),
-    {ok, #state{ref=Ref}}.
+    {ok, maybe_add_rampup(#state{ref=Ref})}.
 
 
 handle_call(run, _From, State) ->
@@ -60,6 +61,9 @@ handle_call(run, _From, State) ->
         start=os:timestamp(),
         duration=DurationMins
     },
+    if NewState#state.rampup_interval =:= undefined -> ok; true ->
+        timer:send_interval(NewState#state.rampup_interval, rampup)
+    end,
     maybe_end({reply, ok, NewState});
 
 handle_call(remaining, _From, State) ->
@@ -90,9 +94,14 @@ handle_info({'DOWN', Ref, process, _Object, Info}, #state{ref=Ref}=State) ->
 handle_info(timeout, State) ->
     {stop, {shutdown, normal}, State};
 
+handle_info(rampup, State) ->
+    ?INFO("Triggering worker rampup", []),
+    basho_bench_worker_sup:add_worker(),
+    maybe_end({noreply, State});
+
 handle_info(Msg, State) ->
     ?WARN("basho_bench_duration handled unexpected info message: ~p", [Msg]),
-    {noreply, State}.
+    maybe_end({noreply, State}).
 
 
 terminate(Reason, #state{duration=DurationMins}) ->
@@ -165,3 +174,13 @@ worker_stopping(WorkerPid) ->
     %% WorkerPid is basho_bench_worker's id, not the pid of actual driver 
     gen_server:cast(?MODULE, {worker_stopping, WorkerPid}),
     ok.
+
+maybe_add_rampup(State) ->
+    case basho_bench_config:get(workers_rampup, undefined) of
+        undefined ->
+            State;
+        Interval when is_integer(Interval) ->
+            State#state{rampup_interval=Interval};
+        Else ->
+            throw({unexpected_rampup, Else})
+    end.

--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -96,7 +96,7 @@ handle_info(timeout, State) ->
 
 handle_info(rampup, State) ->
     ?INFO("Triggering worker rampup", []),
-    basho_bench_worker_sup:add_worker(),
+    add_worker(),
     maybe_end({noreply, State});
 
 handle_info(Msg, State) ->
@@ -185,4 +185,13 @@ maybe_add_rampup(State) ->
             State#state{rampup_interval=Interval};
         Else ->
             throw({unexpected_rampup, Else})
+    end.
+
+add_worker() ->
+    case basho_bench_config:get(workers, undefined) of
+        undefined ->
+            basho_bench_worker_sup:add_worker();
+        [_|_] = Workers ->
+            WorkerTypes = [WT || {WT, _C} <- Workers],
+            basho_bench_worker_sup:add_workers(WorkerTypes)
     end.

--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -183,6 +183,9 @@ maybe_add_rampup(State) ->
             State;
         Interval when is_integer(Interval) ->
             State#state{rampup_interval=Interval};
+        %% TODO: should we support per type intervals?
+        [{_Type, Interval} | _ ] when is_integer(Interval) ->
+            State#state{rampup_interval=Interval};
         Else ->
             throw({unexpected_rampup, Else})
     end.

--- a/src/basho_bench_duration.erl
+++ b/src/basho_bench_duration.erl
@@ -106,6 +106,8 @@ handle_info(Msg, State) ->
 
 terminate(Reason, #state{duration=DurationMins}) ->
     case Reason of
+        normal ->
+            ?CONSOLE("Test completed after ~p mins.\n", [DurationMins]);
         {shutdown, normal} ->
             ?CONSOLE("Test completed after ~p mins.\n", [DurationMins]);
         {shutdown, Reason} ->

--- a/src/basho_bench_stats_writer_csv.erl
+++ b/src/basho_bench_stats_writer_csv.erl
@@ -33,10 +33,10 @@
 
 -export([new/2,
          terminate/1,
-         process_summary/6,
+         process_summary/7,
          report_error/3,
-         report_global_stats/5,
-         report_latency/8]).
+         report_global_stats/6,
+         report_latency/9]).
 
 -include("basho_bench.hrl").
 
@@ -57,7 +57,7 @@ new(Ops, Measurements) ->
         filename:join([TestDir, "summary.csv"]),
         [raw, binary, write]
     ),
-    file:write(SummaryFile, <<"elapsed, window, total_operations, total_units, successful, failed\n">>),
+    file:write(SummaryFile, <<"elapsed, window, concurrency, total_operations, total_units, successful, failed\n">>),
 
     %% Setup errors file w/counters for each error.  Embedded commas likely
     %% in the error messages so quote the columns.
@@ -82,11 +82,12 @@ terminate({SummaryFile, ErrorsFile}) ->
     ok.
 
 process_summary({SummaryFile, _ErrorsFile},
-                Elapsed, Window, Ops, Oks, Errors) ->
+                Elapsed, Window, Concurrency, Ops, Oks, Errors) ->
     file:write(SummaryFile,
-               io_lib:format("~w, ~w, ~w, ~w, ~w, ~w\n",
+               io_lib:format("~w, ~w, ~w, ~w, ~w, ~w, ~w\n",
                              [Elapsed,
                               Window,
+                              Concurrency,
                               Ops + Errors,
                               Oks,
                               Ops,
@@ -98,7 +99,7 @@ report_error({_SummaryFile, ErrorsFile},
                io_lib:format("\"~w\",\"~w\"\n",
                              [Key, Count])).
 
-report_global_stats({Op,_}, Stats, Errors, Units, Ops) ->
+report_global_stats({Op,_}, Stats, Errors, Units, Ops, Concurrency) ->
     %% Build up JSON structure representing statistics collected in folsom
     P = proplists:get_value(percentile, Stats),
     JsonElements0 = lists:foldl(fun(K, Acc) ->
@@ -136,20 +137,24 @@ report_global_stats({Op,_}, Stats, Errors, Units, Ops) ->
     %% insert Ops counts
     JsonElements3 = [{'ops', Ops} | JsonElements2],
 
+    %% insert concurrency
+    JsonElements4 = [{concurrency, Concurrency} | JsonElements3],
+
     JsonMetrics0 = erlang:get(run_metrics),
-    JsonMetrics = lists:keyreplace(Op, 1, JsonMetrics0, {Op, {JsonElements3}}),
+    JsonMetrics = lists:keyreplace(Op, 1, JsonMetrics0, {Op, {JsonElements4}}),
     %?DEBUG("Generated Json:\n~w",[JsonElements]),
     erlang:put(run_metrics, JsonMetrics).
 
 report_latency({_SummaryFile, _ErrorsFile},
-               Elapsed, Window, Op,
+               Elapsed, Window, Concurrency, Op,
                Stats, Errors, Units, Ops) ->
     case proplists:get_value(n, Stats) > 0 of
         true ->
             P = proplists:get_value(percentile, Stats),
-            Line = io_lib:format("~w, ~w, ~w, ~w, ~w, ~.1f, ~w, ~w, ~w, ~w, ~w, ~w\n",
+            Line = io_lib:format("~w, ~w, ~w, ~w, ~w, ~w, ~.1f, ~w, ~w, ~w, ~w, ~w, ~w\n",
                                  [Elapsed,
                                   Window,
+                                  Concurrency,
                                   Units,
                                   Ops,
                                   proplists:get_value(min, Stats),
@@ -177,7 +182,7 @@ op_csv_file({Label, _Op}) ->
     TestDir = basho_bench:get_test_dir(),
     Fname = filename:join([TestDir, normalize_label(Label) ++ "_latencies.csv"]),
     {ok, F} = file:open(Fname, [raw, binary, write]),
-    ok = file:write(F, <<"elapsed, window, n, ops, min, mean, median, 95th, 99th, 99_9th, max, errors\n">>),
+    ok = file:write(F, <<"elapsed, window, concurrency, n, ops, min, mean, median, 95th, 99th, 99_9th, max, errors\n">>),
     F.
 
 measurement_csv_file({Label, _Op}) ->
@@ -190,7 +195,9 @@ measurement_csv_file({Label, _Op}) ->
 
 
 dump_run_statistics(RunStatsType) ->
+    io:format("DUMPING THE RUN STATISTICS: ~p~n", [RunStatsType]),
     Lines = stringify_stats(RunStatsType, erlang:get(run_metrics)),
+    io:format("GOT LINES: ~n~p~n", [Lines]),
     TestDir = basho_bench:get_test_dir(),
     FileName = filename:join([TestDir, "run_statistics." ++ atom_to_list(RunStatsType)]),
     write_run_statistics(FileName, Lines).
@@ -199,7 +206,7 @@ stringify_stats(_RunStatsType=json, RunMetrics) ->
     [ jiffy:encode( {[{recordedMetrics, {RunMetrics}}]}, [pretty] ) ];
 stringify_stats(_RunStatsType=csv, RunMetrics) ->
     % Ordered output of fields
-    OrderedFields = [n, ops, mean, geometric_mean, harmonic_mean,
+    OrderedFields = [n, ops, concurrency, mean, geometric_mean, harmonic_mean,
         variance, standard_deviation, skewness, kurtosis,
         median, p75, p90, p95, p99, p999,
         min, max, basho_errors],

--- a/src/basho_bench_stats_writer_csv.erl
+++ b/src/basho_bench_stats_writer_csv.erl
@@ -195,9 +195,7 @@ measurement_csv_file({Label, _Op}) ->
 
 
 dump_run_statistics(RunStatsType) ->
-    io:format("DUMPING THE RUN STATISTICS: ~p~n", [RunStatsType]),
     Lines = stringify_stats(RunStatsType, erlang:get(run_metrics)),
-    io:format("GOT LINES: ~n~p~n", [Lines]),
     TestDir = basho_bench:get_test_dir(),
     FileName = filename:join([TestDir, "run_statistics." ++ atom_to_list(RunStatsType)]),
     write_run_statistics(FileName, Lines).

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -132,7 +132,10 @@ add_workers([WorkerType|Rest], Acc) when is_atom(WorkerType) ->
 
 
 add_worker_spec(Spec) ->
-    supervisor:start_child(?MODULE, Spec).
+    io:format("STARTING CHILD: ~p~n", [Spec]),
+    Resp = supervisor:start_child(?MODULE, Spec),
+    io:format("    START CHILD RESP: ~p~n", [Resp]),
+    Resp.
 
 
 worker_specs([]) ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -111,7 +111,7 @@ add_worker() ->
 
 
 add_workers(WorkerTypes) ->
-    [add_worker_spec(Spec) || Spec <- add_workers(WorkerTypes, [])].
+    add_workers(WorkerTypes, []).
 
 
 add_workers([], Acc) ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -116,7 +116,7 @@ add_workers(WorkerTypes) ->
 
 add_workers([], Acc) ->
     Acc;
-add_workers([WorkerType|WorkerTypes], Acc) when is_atom(WorkerType) ->
+add_workers([WorkerType|Rest], Acc) when is_atom(WorkerType) ->
     WorkerTypes = basho_bench_config:get(worker_types),
     Conf0 = proplists:get_value(WorkerType, WorkerTypes, []),
     Conf = [{concurrent, 1} | proplists:delete(concurrent, Conf0)],
@@ -128,7 +128,7 @@ add_workers([WorkerType|WorkerTypes], Acc) when is_atom(WorkerType) ->
         {basho_bench_worker, start_link, [Id, {WorkerType, WorkerNum, WorkerNum}, Conf]},
         transient, 5000, worker, [basho_bench_worker]},
     io:format("ADDING WORKER[~p]: ~p~n", [WorkerCount, Spec]),
-    add_workers(WorkerTypes, [add_worker_spec(Spec)|Acc]).
+    add_workers(Rest, [add_worker_spec(Spec)|Acc]).
 
 
 add_worker_spec(Spec) ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -26,7 +26,7 @@
 %% API
 -export([start_link/0,
          add_worker/0,
-         add_worker/1,
+         add_workers/1,
          add_worker_spec/1,
          workers/0,
          workers/1,
@@ -110,7 +110,13 @@ add_worker() ->
     add_worker_spec(Spec).
 
 
-add_worker(WorkerType) when is_atom(WorkerType) ->
+add_workers(WorkerTypes) ->
+    add_workers(WorkerTypes, []).
+
+
+add_workers([], Acc) ->
+    Acc;
+add_workers([WorkerType|WorkerTypes], Acc) when is_atom(WorkerType) ->
     WorkerTypes = basho_bench_config:get(worker_types),
     Conf0 = proplists:get_value(WorkerType, WorkerTypes, []),
     Conf = [{concurrent, 1} | proplists:delete(concurrent, Conf0)],
@@ -122,7 +128,7 @@ add_worker(WorkerType) when is_atom(WorkerType) ->
         {basho_bench_worker, start_link, [Id, {WorkerType, WorkerNum, WorkerNum}, Conf]},
         transient, 5000, worker, [basho_bench_worker]},
     io:format("ADDING WORKER[~p]: ~p~n", [WorkerCount, Spec]),
-    add_worker_spec(Spec).
+    add_workers(WorkerTypes, [add_worker_spec(Spec)|Acc]).
 
 
 add_worker_spec(Spec) ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -111,7 +111,7 @@ add_worker() ->
 
 
 add_workers(WorkerTypes) ->
-    add_workers(WorkerTypes, []).
+    [add_worker_spec(Spec) || Spec <- add_workers(WorkerTypes, [])].
 
 
 add_workers([], Acc) ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -127,15 +127,11 @@ add_workers([WorkerType|Rest], Acc) when is_atom(WorkerType) ->
         Id,
         {basho_bench_worker, start_link, [Id, {WorkerType, WorkerNum, WorkerNum}, Conf]},
         transient, 5000, worker, [basho_bench_worker]},
-    io:format("ADDING WORKER[~p]: ~p~n", [WorkerCount, Spec]),
     add_workers(Rest, [add_worker_spec(Spec)|Acc]).
 
 
 add_worker_spec(Spec) ->
-    io:format("STARTING CHILD: ~p~n", [Spec]),
-    Resp = supervisor:start_child(?MODULE, Spec),
-    io:format("    START CHILD RESP: ~p~n", [Resp]),
-    Resp.
+    {ok, _Pid} = supervisor:start_child(?MODULE, Spec).
 
 
 worker_specs([]) ->

--- a/src/basho_bench_worker_sup.erl
+++ b/src/basho_bench_worker_sup.erl
@@ -25,8 +25,12 @@
 
 %% API
 -export([start_link/0,
+         add_worker/0,
+         add_worker/1,
+         add_worker_spec/1,
          workers/0,
          workers/1,
+         worker_count/0,
          remote_workers/1,
          stop_child/1,
          active_workers/0]).
@@ -58,6 +62,21 @@ stop_child(Id) ->
 active_workers() ->
     [X || X <- workers(), X =/= undefined].
 
+worker_count() ->
+    case whereis(?MODULE) of
+        undefined ->
+            case erlang:get(last_worker_count) of
+                undefined ->
+                    0;
+                WC ->
+                    WC
+            end;
+        _Pid ->
+            WC = length(active_workers()),
+            erlang:put(last_worker_count, WC),
+            WC
+    end.
+
 
 %% ===================================================================
 %% Supervisor callbacks
@@ -76,6 +95,38 @@ init([]) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+
+add_worker() ->
+    WorkerCount = length(active_workers()),
+    WorkerNum = WorkerCount + 1,
+    Id = list_to_atom(lists:concat(['basho_bench_rampup_worker_', WorkerNum])),
+    %% Use "single_worker" atom for original non-worker case
+    Spec = {
+        Id,
+        {basho_bench_worker, start_link, [Id, {single_worker, WorkerNum, WorkerNum}, []]},
+        transient, 5000, worker, [basho_bench_worker]
+    },
+    add_worker_spec(Spec).
+
+
+add_worker(WorkerType) when is_atom(WorkerType) ->
+    WorkerTypes = basho_bench_config:get(worker_types),
+    Conf0 = proplists:get_value(WorkerType, WorkerTypes, []),
+    Conf = [{concurrent, 1} | proplists:delete(concurrent, Conf0)],
+    WorkerCount = length(active_workers()),
+    WorkerNum = WorkerCount + 1,
+    Id = list_to_atom(lists:concat(['basho_bench_rampup_worker_', WorkerType, '_', WorkerNum])),
+    Spec = {
+        Id,
+        {basho_bench_worker, start_link, [Id, {WorkerType, WorkerNum, WorkerNum}, Conf]},
+        transient, 5000, worker, [basho_bench_worker]},
+    io:format("ADDING WORKER[~p]: ~p~n", [WorkerCount, Spec]),
+    add_worker_spec(Spec).
+
+
+add_worker_spec(Spec) ->
+    supervisor:start_child(?MODULE, Spec).
 
 
 worker_specs([]) ->


### PR DESCRIPTION
This introduces the notion of a "worker rampup", which allows for setting a time interval (in milliseconds) to specify how often to instantiate a new worker, in addition to the normal concurrency setting, which now acts as a base level concurrency in the case of enabled worker rampup.

This PR also extends the stats collection logic and reporting such that concurrency is one of the columnar outputs of the results documents. The idea here being to be able to see how latency and throughput are affected over time as a function of worker count.