### PR TITLE
187 fdb acceptance jiffy chewbranca

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,8 +10,7 @@
   {getopt, ".*", {git, "git://github.com/jcomellas/getopt", {tag, "v0.8.2"}}},
   {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.6.8"}}},
   {ibrowse, ".*", {git, "https://github.com/apache/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},
-  {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}},
-  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "1.0.4"}}}
+  {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}}
  ]}.
 
 {erl_opts, [{src_dirs, [src]}, {parse_transform, lager_transform}]}.
@@ -22,7 +21,6 @@
     getopt,
     goldrush,
     ibrowse,
-    jiffy,
     lager
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
   {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.6.8"}}},
   {ibrowse, ".*", {git, "https://github.com/apache/couchdb-ibrowse.git", "4af2d408607874d124414ac45df1edbe3961d1cd"}},
   {goldrush, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-goldrush.git",  {tag, "0.1.6"}}},
-  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.14.7"}}}
+  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "1.0.4"}}}
  ]}.
 
 {erl_opts, [{src_dirs, [src]}, {parse_transform, lager_transform}]}.

--- a/src/basho_bench_stats_writer_csv.erl
+++ b/src/basho_bench_stats_writer_csv.erl
@@ -73,8 +73,7 @@ terminate({SummaryFile, ErrorsFile}) ->
     ?INFO("module=~s event=stop stats_sink=csv\n", [?MODULE]),
 
     %% write out run-wide statistics before exiting
-    RunStatsType = basho_bench_config:get(run_statistics_output_format, csv),
-    dump_run_statistics(RunStatsType),
+    dump_run_statistics(),
 
     [ok = file:close(F) || {{csv_file, _}, F} <- erlang:get()],
     ok = file:close(SummaryFile),
@@ -189,15 +188,13 @@ measurement_csv_file({Label, _Op}) ->
 
 
 
-dump_run_statistics(RunStatsType) ->
-    Lines = stringify_stats(RunStatsType, erlang:get(run_metrics)),
+dump_run_statistics() ->
+    Lines = stringify_stats(erlang:get(run_metrics)),
     TestDir = basho_bench:get_test_dir(),
-    FileName = filename:join([TestDir, "run_statistics." ++ atom_to_list(RunStatsType)]),
+    FileName = filename:join([TestDir, "run_statistics.csv"]),
     write_run_statistics(FileName, Lines).
 
-stringify_stats(_RunStatsType=json, RunMetrics) ->
-    [ jiffy:encode( {[{recordedMetrics, {RunMetrics}}]}, [pretty] ) ];
-stringify_stats(_RunStatsType=csv, RunMetrics) ->
+stringify_stats(RunMetrics) ->
     % Ordered output of fields
     OrderedFields = [n, ops, mean, geometric_mean, harmonic_mean,
         variance, standard_deviation, skewness, kurtosis,


### PR DESCRIPTION
This removes run_statistics file output formats for json files, as it's not being used at all and needs to be updated to work with the latest Jiffy version. It wouldn't be hard to fix it, but given it's not being used at all, let's just remove it.