### PR TITLE
Add detect-secrets integration with GitHub Actions and Makefile

### DIFF
--- a/.github/workflows/detect-secrets.yaml
+++ b/.github/workflows/detect-secrets.yaml
@@ -1,0 +1,42 @@
+name: Detect Secrets Scan
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [cloudant]
+
+jobs:
+  detect-secrets:
+    name: Scan for Secrets (uses committed baseline config)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install detect-secrets
+        run: pip install git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets
+
+      - name: Compare baseline
+        run: |
+          cp .secrets.baseline .secrets.baseline.bak
+          detect-secrets scan --update .secrets.baseline --suppress-unscannable-file-warnings
+
+          grep -v '"generated_at":' .secrets.baseline.bak > before.cleaned
+          grep -v '"generated_at":' .secrets.baseline     > after.cleaned
+
+          if ! diff before.cleaned after.cleaned > secrets.diff; then
+            echo "::error::Secrets baseline changed (excluding timestamp)."
+            cat secrets.diff
+            rm .secrets.baseline.bak before.cleaned after.cleaned secrets.diff
+            exit 1
+          else
+            echo "✅ No actual secret changes detected."
+            rm .secrets.baseline.bak before.cleaned after.cleaned secrets.diff
+          fi

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,111 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2025-08-01T05:50:53Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "examples/cs.config.sample": [
+      {
+        "hashed_secret": "0bb078fe348593875f24c6402ea1f766decf7234",
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "rebar.config": [
+      {
+        "hashed_secret": "f76bb956cd320d9d363dafdcfa7d3d772632179e",
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bccb22846e7379f876d9dea83ece103a2daef8f0",
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,34 @@ package: package.src
 
 pkgclean: distclean
 	rm -rf package
+
+.PHONY: update-secrets
+
+update-secrets:
+	@echo "🚀 Starting detect-secrets workflow..."
+
+	# 🧼 Clean any existing virtual environment
+	@echo "🧹 Cleaning old virtual environment (if any)..."
+	@rm -rf .venv-ds
+
+	# 🛠️  Set up a new virtual environment
+	@echo "🐍 Creating fresh virtual environment at .venv-ds..."
+	@python3 -m venv .venv-ds
+
+	# 📦 Upgrade pip silently
+	@echo "📦 Upgrading pip..."
+	@.venv-ds/bin/pip install --upgrade pip > /dev/null
+
+	# 🔍 Install latest detect-secrets
+	@echo "🔐 Installing detect-secrets..."
+	@.venv-ds/bin/pip install git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets > /dev/null
+
+	# 📊 Scan and update the baseline
+	@echo "🔎 Scanning for secrets and updating .secrets.baseline..."
+	@.venv-ds/bin/detect-secrets scan --update .secrets.baseline --suppress-unscannable-file-warnings
+
+	# 🧽 Cleanup the virtual environment
+	@echo "🧼 Removing virtual environment..."
+	@rm -rf .venv-ds
+
+	@echo "✅ Done! .secrets.baseline is updated."

--- a/README.org
+++ b/README.org
@@ -203,3 +203,26 @@ $ ./priv/gp_latencies.sh
 
    6) A Basho engineer or community maintainer will review your patch
       and merge it into the main repository or send you feedback.
+
+* 🔐 Detect Secrets Enforcement
+
+This repository uses [`detect-secrets`](https://github.com/IBM/detect-secrets-stream) to prevent committing sensitive information like API keys, tokens, and passwords.
+
+** 🚀 How It Works
+
+Secrets are tracked using a `.secrets.baseline` file. This file contains a hash of detected secret patterns and is version-controlled.
+
+On every pull request, GitHub Actions will:
+- Scan the codebase using the committed baseline.
+- Fail the build if new untracked secrets are found.
+
+** 🛠 Update the Baseline
+
+If your PR is failing due to newly detected secrets (false positives or intentional additions), follow the steps below to update the baseline:
+
+*** ✅ One-Command Update
+
+Use the provided `Makefile` to automatically install and run `detect-secrets`, then clean up:
+
+```bash
+make update-secrets


### PR DESCRIPTION
Issue: https://github.ibm.com/cloudant/releng/issues/1062

Added GitHub Action to scan secrets on PRs
Included Makefile for easy baseline updates
Auto-installs detect-secrets and cleans up
Added short README for developer usage
Configured baseline with exclusions and plugin tweaks